### PR TITLE
Fix compilation bugs in engines (Boost includes, script robustness)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "engines/bipartiteSBM-MCMC"]
 	path = engines/bipartiteSBM-MCMC
-	url = https://github.com/junipertcy/bipartiteSBM-MCMC.git
+	url = https://github.com/skojaku/bipartiteSBM-MCMC.git
 [submodule "engines/bipartiteSBM-KL"]
 	path = engines/bipartiteSBM-KL
 	url = https://github.com/junipertcy/bipartiteSBM-KL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "engines/bipartiteSBM-MCMC"]
 	path = engines/bipartiteSBM-MCMC
-	url = https://github.com/skojaku/bipartiteSBM-MCMC.git
+	url = https://github.com/junipertcy/bipartiteSBM-MCMC.git
 [submodule "engines/bipartiteSBM-KL"]
 	path = engines/bipartiteSBM-KL
 	url = https://github.com/junipertcy/bipartiteSBM-KL.git

--- a/scripts/compile_engines.sh
+++ b/scripts/compile_engines.sh
@@ -2,7 +2,7 @@
 set -e
 
 (
-  cd engines/bipartiteSBM-MCMC/ && cmake -DBOOST_ROOT=/tmp/boost_local . && make
+  cd engines/bipartiteSBM-MCMC/ && cmake . && make
 )
 (
   cd engines/bipartiteSBM-KL/ && g++ -O3 -Wall -g -pedantic -o biSBM biSBM.cpp

--- a/scripts/compile_engines.sh
+++ b/scripts/compile_engines.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -e
 
-cd engines/bipartiteSBM-MCMC/ && cmake . && make && cd -
-cd engines/bipartiteSBM-KL/ && g++ -O3 -Wall -g -pedantic -o biSBM biSBM.cpp && cd -
+(
+  cd engines/bipartiteSBM-MCMC/ && cmake -DBOOST_ROOT=/tmp/boost_local . && make
+)
+(
+  cd engines/bipartiteSBM-KL/ && g++ -O3 -Wall -g -pedantic -o biSBM biSBM.cpp
+)


### PR DESCRIPTION
# Pull Request: Fix C++ engine compilation

## Problem
Issue #14: the C++ engines would not build. Two bugs were blocking compilation, and a third issue made failures hard to debug.

## Changes

### 1. CMake could not find Boost headers

The build system was told where to find the Boost library files but not where to find the Boost header files.  The compiler could not locate the header it needed.

**Fix in `engines/bipartiteSBM-MCMC/CMakeLists.txt`:**

```diff
 find_package( Boost 1.40 COMPONENTS program_options )
 if (Boost_FOUND)
     set(HAVE_LIBBOOST_PROGRAM_OPTIONS 1)
+    include_directories(${Boost_INCLUDE_DIRS})
 else()
     message(STATUS "C++ Boost::program_options is not installed. Using limited interface.")
     set(HAVE_LIBBOOST_PROGRAM_OPTIONS 0)
```

### 2. Build script failed in confusing ways

The script built each engine by stepping into its folder, running the build, then stepping back out. If a build failed in the middle, the script never stepped back out, so the next engine's build looked for a folder relative to the wrong location.

**Fix in `scripts/compile_engines.sh`:**

```diff
 #!/bin/bash
+set -e
 
-cd engines/bipartiteSBM-MCMC/ && cmake . && make && cd -
-cd engines/bipartiteSBM-KL/ && g++ -O3 -Wall -g -pedantic -o biSBM biSBM.cpp && cd -
+(
+  cd engines/bipartiteSBM-MCMC/ && cmake . && make
+)
+(
+  cd engines/bipartiteSBM-KL/ && g++ -O3 -Wall -g -pedantic -o biSBM biSBM.cpp
+)
```

The subshells `( )` isolate each build so directory changes never leak.

## Verification
Builds cleanly on a local Ubuntu 22.04 machine and in a fresh Ubuntu 22.04 Docker container.

## Upstream
A matching fix has been submitted to the original `bipartiteSBM-MCMC` repository: **junipertcy/bipartiteSBM-MCMC/pull/3**